### PR TITLE
feat($retry): enable exponential backoff via keyword arguments

### DIFF
--- a/funcy/flow.py
+++ b/funcy/flow.py
@@ -124,7 +124,7 @@ def retry(call, tries, errors=Exception, timeout=0, filter_errors=None, exp=1, c
        Retries only on specified errors.
        Sleeps timeout or timeout(attempt) seconds between tries.
        Interval can grow exponentially up to cap value.
-       Interval can make random offset according to jitter."""
+       Interval can make random offset according to jitter_amp."""
     errors = _ensure_exceptable(errors)
     for attempt in range(tries):
         try:

--- a/funcy/flow.py
+++ b/funcy/flow.py
@@ -1,4 +1,6 @@
 from datetime import datetime, timedelta
+from math import inf
+from random import uniform
 import time
 import threading
 
@@ -117,10 +119,12 @@ def reraise(errors, into):
 
 
 @decorator
-def retry(call, tries, errors=Exception, timeout=0, filter_errors=None):
+def retry(call, tries, errors=Exception, timeout=0, filter_errors=None, exp=1, cap=inf, jitter=1):
     """Makes decorated function retry up to tries times.
        Retries only on specified errors.
-       Sleeps timeout or timeout(attempt) seconds between tries."""
+       Sleeps timeout or timeout(attempt) seconds between tries.
+       Interval can grow exponentially up to cap value.
+       Interval can make random offset according to jitter."""
     errors = _ensure_exceptable(errors)
     for attempt in range(tries):
         try:
@@ -134,6 +138,9 @@ def retry(call, tries, errors=Exception, timeout=0, filter_errors=None):
                 raise
             else:
                 timeout_value = timeout(attempt) if callable(timeout) else timeout
+                timeout_value *= exp ** attempt
+                timeout_value *= uniform(float(1/jitter), float(jitter))
+                timeout_value = min(timeout_value, cap)
                 if timeout_value > 0:
                     time.sleep(timeout_value)
 

--- a/funcy/flow.py
+++ b/funcy/flow.py
@@ -119,7 +119,7 @@ def reraise(errors, into):
 
 
 @decorator
-def retry(call, tries, errors=Exception, timeout=0, filter_errors=None, exp=1, cap=inf, jitter=1):
+def retry(call, tries, errors=Exception, timeout=0, filter_errors=None, exp=1, cap=inf, jitter_amp=1):
     """Makes decorated function retry up to tries times.
        Retries only on specified errors.
        Sleeps timeout or timeout(attempt) seconds between tries.
@@ -139,7 +139,7 @@ def retry(call, tries, errors=Exception, timeout=0, filter_errors=None, exp=1, c
             else:
                 timeout_value = timeout(attempt) if callable(timeout) else timeout
                 timeout_value *= exp ** attempt
-                timeout_value *= uniform(float(1/jitter), float(jitter))
+                timeout_value *= uniform(float(1/jitter_amp), float(jitter_amp))
                 timeout_value = min(timeout_value, cap)
                 if timeout_value > 0:
                     time.sleep(timeout_value)

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -134,7 +134,7 @@ def test_retry_timeout_jitter(monkeypatch):
     timeouts = []
     monkeypatch.setattr('time.sleep', timeouts.append)
 
-    retry_deco = retry(5, MyError, timeout=1, jitter=0.5)
+    retry_deco = retry(5, MyError, timeout=1, jitter_amp=0.5)
     with pytest.raises(MyError):
         retry_deco(_make_failing(n=5))()
     assert all([0.5 <= t <= 2.0 for t in timeouts])

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -107,6 +107,39 @@ def test_retry_timeout(monkeypatch):
     assert timeouts == [1, 2, 4]
 
 
+def test_retry_timeout_exp(monkeypatch):
+
+    timeouts = []
+    monkeypatch.setattr('time.sleep', timeouts.append)
+
+    retry_deco = retry(5, MyError, timeout=1, exp=2)
+    with pytest.raises(MyError):
+        retry_deco(_make_failing(n=5))()
+    assert timeouts == [1, 2, 4, 8]
+
+
+def test_retry_timeout_exp_with_cap(monkeypatch):
+
+    timeouts = []
+    monkeypatch.setattr('time.sleep', timeouts.append)
+
+    retry_deco = retry(5, MyError, timeout=1, exp=2, cap=5)
+    with pytest.raises(MyError):
+        retry_deco(_make_failing(n=5))()
+    assert timeouts == [1, 2, 4, 5]
+
+
+def test_retry_timeout_jitter(monkeypatch):
+
+    timeouts = []
+    monkeypatch.setattr('time.sleep', timeouts.append)
+
+    retry_deco = retry(5, MyError, timeout=1, jitter=0.5)
+    with pytest.raises(MyError):
+        retry_deco(_make_failing(n=5))()
+    assert all([0.5 <= t <= 2.0 for t in timeouts])
+
+
 def test_retry_many_errors():
     assert retry(2, (MyError, RuntimeError))(_make_failing())() == 1
     assert retry(2, [MyError, RuntimeError])(_make_failing())() == 1
@@ -119,7 +152,6 @@ def test_retry_filter():
     assert retry_deco(_make_failing(e=MyError('x')))() == 1
     with pytest.raises(MyError):
         retry_deco(_make_failing())()
-
 
 def _make_failing(n=1, e=MyError):
     calls = []

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -153,6 +153,7 @@ def test_retry_filter():
     with pytest.raises(MyError):
         retry_deco(_make_failing())()
 
+
 def _make_failing(n=1, e=MyError):
     calls = []
 


### PR DESCRIPTION
# Summary
- Enable exponential backoff via keyword arguments.

# Checklist
- [x] Implement unit test cases.

# Reason
- Currently, the feature supports highly customized retry intervals via a pass-in callable argument.
- However, it's hard to comprehend that the argument  `timeout` can also accept a callable object without tracing the source code.
- Capped exponential backoffs and jitter are already well-known approaches, maybe you can consider making them a specific feature via keyword arguments.